### PR TITLE
Add JPEG compression to image ZIP app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # Test
 just to test codex
+
+## Image Compression App
+
+This repository includes a small Flask application that lets you select multiple images and specify a folder name. Each image is compressed to JPEG format with reduced quality before being packaged into a ZIP archive. The UI is a simple HTML form.
+
+### Setup
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python image_compressor/app.py
+```
+
+Visit [http://localhost:5000](http://localhost:5000) in your browser and upload images to receive a ZIP archive containing the compressed JPEGs.

--- a/image_compressor/app.py
+++ b/image_compressor/app.py
@@ -1,0 +1,37 @@
+from flask import Flask, render_template, request, send_file
+from werkzeug.utils import secure_filename
+from PIL import Image
+import zipfile
+import io
+
+app = Flask(__name__)
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        folder_name = request.form.get('folder')
+        files = request.files.getlist('images')
+        if not folder_name or not files:
+            return 'Please provide folder name and at least one image', 400
+        memory_file = io.BytesIO()
+        with zipfile.ZipFile(memory_file, 'w', zipfile.ZIP_DEFLATED) as zipf:
+            for file in files:
+                filename = secure_filename(file.filename)
+                img = Image.open(file.stream)
+                if img.mode in ("RGBA", "P"):
+                    img = img.convert("RGB")
+                buf = io.BytesIO()
+                img.save(buf, format='JPEG', optimize=True, quality=85)
+                buf.seek(0)
+                zipf.writestr(f"{folder_name}/{filename}", buf.read())
+        memory_file.seek(0)
+        return send_file(
+            memory_file,
+            mimetype='application/zip',
+            as_attachment=True,
+            download_name=f"{folder_name}.zip"
+        )
+    return render_template('index.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/image_compressor/templates/index.html
+++ b/image_compressor/templates/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Image Compressor</title>
+</head>
+<body>
+    <h1>Upload Images to Compress</h1>
+    <p>Select your product images, choose a folder name, and the server will return
+       a ZIP archive of compressed JPEGs.</p>
+    <form action="/" method="post" enctype="multipart/form-data">
+        <label for="folder">Folder name:</label>
+        <input type="text" id="folder" name="folder" required>
+        <br><br>
+        <label for="images">Select images:</label>
+        <input type="file" id="images" name="images" accept="image/*" multiple required>
+        <br><br>
+        <button type="submit">Compress</button>
+    </form>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Pillow


### PR DESCRIPTION
## Summary
- compress uploaded images to JPEG using Pillow before zipping
- document JPEG compression in the README
- mention Pillow in requirements
- update HTML with short instructions

## Testing
- `python -m py_compile image_compressor/app.py`


------
https://chatgpt.com/codex/tasks/task_e_686faf80ca80832d898b4be33a8ed72a